### PR TITLE
BunnyCompilerPass potentially reflects on classes that don't exist

### DIFF
--- a/DependencyInjection/Compiler/BunnyCompilerPass.php
+++ b/DependencyInjection/Compiler/BunnyCompilerPass.php
@@ -80,6 +80,11 @@ class BunnyCompilerPass implements CompilerPassInterface
 			}
 
 			$className = $parameterBag->resolveValue($definition->getClass());
+
+			if (!class_exists($className)) {
+				continue;
+			}
+
 			$rc = new \ReflectionClass($className);
 
 			if (strpos($rc->getDocComment(), "@Consumer") === false && strpos($rc->getDocComment(), "@Producer") === false) {


### PR DESCRIPTION
The BunnyCompilerPass is trying to run reflection on everything in the container, and some bundles declare optional services for dependencies that you may not have installed. If this is the case, there will be an exception when trying to reflect on a classname that does not exist.

Another package I have installed declares a service I don't use relating to Doctrine's MongoDB ODM. Therefore, bunny bundle will give me this error:

```
[ReflectionException]
    Class Doctrine\MongoDB\Database does not exist
```

This PR should be a quick fix to that.
